### PR TITLE
ci: drop duplicate pull_request trigger from image builds

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,8 +1,9 @@
 name: Image CI Build
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # NOTE: PR builds run on pull_request_target only. A plain pull_request
+  # trigger would double every PR build, and its run takes the branch/tag
+  # code path below, which also pushes the :latest tag from PRs.
   pull_request_target:
     types: [opened, synchronize, reopened]
   push:


### PR DESCRIPTION
`images.yaml` fires on both `pull_request` **and** `pull_request_target`, so every PR builds twice — e.g. runs [30257380951](https://github.com/snapp-incubator/hubble-ui/actions/runs/30257380951) and [30257377825](https://github.com/snapp-incubator/hubble-ui/actions/runs/30257377825) for the same commit on #31.

Worse, the `pull_request` run satisfies `github.event_name != 'pull_request_target'`, so it takes the branch/tag code path — which pushes the `:latest` tag from a pull request.

This keeps `pull_request_target` only. That's the trigger that gets a writable `GITHUB_TOKEN` on dependabot PRs; plain `pull_request` does not.

### Note: this does not fix the ghcr push failure

`denied: permission_denied: write_package` has a separate cause. The token is already correct (`Packages: write`, `Login Succeeded!`). The `ghcr.io/snapp-incubator/hubble-ui` and `hubble-ui-backend` packages were created **2025-08-18**, before this repo existed (**2025-09-29**), and their existing tags (`ce57828d…`, `3080ff36…`) are not commits in this repo. They were pushed out-of-band and were never granted Actions access to this repository, so a repo-scoped `GITHUB_TOKEN` is denied regardless of the `permissions:` block.

Fix is in the package settings UI (org owner): **Manage Actions access → add `snapp-incubator/hubble-ui` with the Write role**, for both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)