### PR TITLE
ci: enable codeql for this fork and bump codeql-action to v4.37.6

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,12 +38,12 @@ jobs:
         with:
           go-version-file: ./backend/go.mod
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-        uses: github/codeql-action/autobuild@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: '/language:${{matrix.language}}'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,12 +4,11 @@ name: codeql
 on:
   push:
     branches:
-      - 'dev-refactor'
-      - 'master'
+      - 'main'
       - 'v*'
   pull_request:
     branches:
-      - 'master'
+      - 'main'
   schedule:
     - cron: '45 7 * * 3'
 
@@ -19,7 +18,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: github.repository == 'cilium/hubble-ui'
+    if: github.repository == 'snapp-incubator/hubble-ui'
     name: Analyze
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Two commits, both about making CodeQL actually function in this fork.

### 1. Enable it (`647e82cc`)

The workflow came from upstream and **has never run here**, for two independent reasons:

- the job is gated `if: github.repository == 'cilium/hubble-ui'`
- its triggers target `master`/`dev-refactor`, but this fork's default branch is `main`

Both are now pointed at this fork. `push` on `v*` and the weekly `schedule` are unchanged.

### 2. Bump the action (`f3fb1032`)

`init`, `autobuild`, and `analyze` go from v3.35.1 to v4.37.6 (released 2026-08-04), pinned by SHA `5595ccaf` to match the convention used elsewhere on `main`. This was the one genuinely-new item in the stale dependabot group closed as #21 — everything else there was already at or behind `main`.

### Verifying

This PR is its own test: with the trigger fix in place, the `codeql` workflow should appear in this PR's checks. If it does, both languages (`go`, `javascript-typescript`) are analyzing and results will start flowing to the Security tab. First run may take a few minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)