### PR TITLE
ci: restore dependabot config for this fork

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,84 @@
+version: 2
+
+# NOTE: upstream cilium/hubble-ui migrated to Renovate and deleted this file.
+# This fork does not have the Renovate GitHub App installed, and
+# .github/renovate.json5 targets a `master` base branch that does not exist
+# here, so that config is inert. Dependency updates run on Dependabot instead.
+#
+# Differences from the upstream config this is derived from:
+#   - `rebase-strategy: disabled` is NOT set. Upstream disables rebasing, which
+#     is what left PRs #21-#30 stranded on a pre-rebase base commit until they
+#     conflicted and had to be closed. Letting Dependabot rebase keeps open PRs
+#     mergeable against main.
+#   - Lower open-PR limits (5 per ecosystem upstream -> 2-3 here), since this
+#     fork has far less review capacity than upstream.
+#   - Labels reduced to ones that exist in this repo.
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+    groups:
+      prod-deps:
+        dependency-type: production
+      dev-deps:
+        dependency-type: development
+
+  - package-ecosystem: gomod
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2
+    labels:
+      - dependencies
+    ignore:
+      # Tracks the Cilium version deployed in the cluster; bump deliberately
+      # alongside that upgrade rather than automatically.
+      - dependency-name: github.com/cilium/cilium
+      - dependency-name: github.com/cilium/hubble
+    groups:
+      go-deps:
+        patterns:
+          - '*'
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2
+    labels:
+      - dependencies
+      - ci
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: 'docker:'
+    open-pull-requests-limit: 2
+    labels:
+      - dependencies
+
+  - package-ecosystem: docker
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: 'backend/docker:'
+    open-pull-requests-limit: 2
+    labels:
+      - dependencies


### PR DESCRIPTION
### Problem

The upstream rebase (#31) pulled in `489e020a`, which deleted `.github/dependabot.yml` because **upstream** migrated to Renovate. This fork did not migrate with it:

- the Renovate GitHub App is not installed on `snapp-incubator` — it has produced **zero PRs, ever**
- `.github/renovate.json5` sets `baseBranchPatterns: ['master']`, and this fork's default branch is `main`

So the rebase silently left this fork with **no dependency automation at all**. The five stale Dependabot PRs closed alongside #32 were the tail of the old config, not ongoing activity.

### Fix

Restore Dependabot, which demonstrably works here — it authored PRs #4 through #30 — tuned for a fork rather than for upstream:

| | upstream | here | why |
|---|---|---|---|
| `rebase-strategy` | `disabled` | *unset* (auto) | **the important one** — see below |
| `open-pull-requests-limit` | 5 per ecosystem | 2–3 | ~11 max open instead of 25 |
| labels | 4 cilium-specific | `dependencies`, `ci` | the upstream ones don't exist in this repo |

Dropping `rebase-strategy: disabled` is the fix for the failure mode we just cleaned up. Upstream sets it, which is precisely why #21–#30 sat pinned to a pre-rebase base commit for up to nine months, drifted into conflict, and had to be closed unmerged. With auto-rebase, Dependabot keeps open PRs mergeable against `main`.

The `cilium/cilium` and `cilium/hubble` ignores are kept — those track the Cilium version deployed in the cluster and should be bumped deliberately alongside that upgrade.

### Notes

- `gomod` targets `/backend`, which vendors (6572 files under `backend/vendor/`). Dependabot detects and updates vendored Go modules, so its PRs should satisfy the `go mod vendor` check in `tests.yml`. Worth confirming on the first Go PR.
- `renovate.json5` is left in place, untouched. It's inert, but keeping it reduces conflict surface on the next upstream rebase. If the Renovate App is ever installed, disable one of the two to avoid duplicate PRs.
- The `dependencies` and `ci` labels have been created in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)