### PR TITLE
ci: retarget release image builds at ghcr.io/snapp-incubator

### DIFF
--- a/.github/workflows/images-releases.yaml
+++ b/.github/workflows/images-releases.yaml
@@ -6,11 +6,14 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-push:
-    if: ${{ github.repository == 'cilium/hubble-ui' }}
+    if: ${{ github.repository == 'snapp-incubator/hubble-ui' }}
     timeout-minutes: 30
-    environment: release
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -27,25 +30,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      - name: Login to DockerHub
+      - name: Login to ghcr.io
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
-          username: ${{ secrets.DOCKER_HUB_RELEASE_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_RELEASE_PASSWORD }}
-
-      - name: Login to quay.io
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME_RELEASE_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD_RELEASE_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Getting image tag
         id: tag
         run: |
           tag=${GITHUB_REF##*/}
           echo tag=$tag >> $GITHUB_OUTPUT
-          echo image_tags=quay.io/cilium/${{ matrix.name }}:$tag >> $GITHUB_OUTPUT
+          echo image_tags=ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:$tag >> $GITHUB_OUTPUT
 
       - name: Checkout Source Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -75,7 +72,7 @@ jobs:
 
           echo "### ${{ matrix.name }}" > image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
-          echo "\`quay.io/cilium/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "\`ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
 
       # Upload artifact digests
@@ -87,7 +84,7 @@ jobs:
           retention-days: 1
 
   image-digests:
-    if: ${{ github.repository == 'cilium/hubble-ui' }}
+    if: ${{ github.repository == 'snapp-incubator/hubble-ui' }}
     name: Display Digests
     runs-on: ubuntu-latest
     needs: build-and-push


### PR DESCRIPTION
### Problem

`images-releases.yaml` was inherited from upstream unchanged and **has never run here**:

- both jobs are gated `if: github.repository == 'cilium/hubble-ui'`
- it publishes to `quay.io/cilium/*` using `DOCKER_HUB_RELEASE_*` and `QUAY_*_RELEASE_*` secrets this fork doesn't have
- it requires a GitHub Environment named `release`, and this fork has **no environments defined**

Concretely: tag `v1.5.0` was pushed, and [run 30279927901](https://github.com/snapp-incubator/hubble-ui/actions/runs/30279927901) was **skipped**. That release produced no images.

### Fix

Point it at `ghcr.io/snapp-incubator/*`, matching where CI images already go:

- gate both jobs on `snapp-incubator/hubble-ui`
- replace the DockerHub and quay logins with a single `ghcr.io` login using the built-in `GITHUB_TOKEN` — **no new secrets required**
- add the `packages: write` permission that token needs to push
- drop `environment: release`, which gated on a nonexistent environment and no longer holds any secrets we use
- update the digest output text, which hardcoded `quay.io/cilium/`

Both Dockerfiles have the `AS release` stage that `target: release` expects, so the build steps are unchanged.

### Verifying

This can't be exercised by a PR — the workflow only triggers on `v*.*.*` tags. After merge, the next release tag should publish `ghcr.io/snapp-incubator/hubble-ui:<tag>` and `ghcr.io/snapp-incubator/hubble-ui-backend:<tag>`.

To backfill the missed `v1.5.0` images, re-push the tag once this is on `main`.

### Note on package visibility

New GHCR packages default to **private**. If anything pulls these images anonymously, the package visibility needs to be set to public in org package settings after the first push — that's a one-time UI step I can't do from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)